### PR TITLE
fixed minor summary generation bug

### DIFF
--- a/sports_digest_gpt_core_functions.py
+++ b/sports_digest_gpt_core_functions.py
@@ -102,11 +102,6 @@ def get_single_game_boxscore_data(db, game_dict):
 
         df = pd.DataFrame(data, columns=columns)
 
-        #TODO: Remove writing to file once we are ready to deploy
-        with open("test_files/test.txt", 'a') as f:
-            f.write(df.to_string())
-            f.write('\n\n')
-
         boxscore_tables += df.to_string(index=False) + "\n\n"
 
     boxscore_data = {


### PR DESCRIPTION
Before I implemented the FIrestore DB in the backend, I was writing the generated summaries to a text file for testing purposes and forgot to remove it in the deployed code. Cloud Functions operate in a read-only env so writing to files doesn't work and thus the summary generation job fails.